### PR TITLE
- Fixed binormal handedness getting bashed in shape data.

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -4320,6 +4320,7 @@ namespace xivModdingFramework.Models.FileTypes
 
                                             var normal = meshData.VertexData.Normals[vertIndex];
                                             var binormal = meshData.VertexData.BiNormals[vertIndex];
+                                            var binormalHandedness = meshData.VertexData.BiNormalHandedness[vertIndex];
                                             var color = meshData.VertexData.Colors[vertIndex];
                                             var textureCoordinates0 = meshData.VertexData.TextureCoordinates0[vertIndex];
                                             var textureCoordinates1 = meshData.VertexData.TextureCoordinates1[vertIndex];
@@ -4331,7 +4332,7 @@ namespace xivModdingFramework.Models.FileTypes
                                             importData.VertexData1.Add((byte)((Math.Abs(binormal.X) * 255 + 255) / 2));
                                             importData.VertexData1.Add((byte)((Math.Abs(binormal.Y) * 255 + 255) / 2));
                                             importData.VertexData1.Add((byte)((Math.Abs(binormal.Z) * 255 + 255) / 2));
-                                            importData.VertexData1.Add(0);
+                                            importData.VertexData1.Add(binormalHandedness);
 
                                             importData.VertexData1.Add(color.R);
                                             importData.VertexData1.Add(color.G);
@@ -5152,7 +5153,7 @@ namespace xivModdingFramework.Models.FileTypes
 
             for (var i = 0; i < vertexData.Normals.Count; i++)
             {
-                if (vertexInfoDict[VertexUsageType.Normal] == VertexDataType.Float3)
+                if (vertexInfoDict[VertexUsageType.Normal] == VertexDataType.Half4)
                 {
                     // Normals
                     var x = new Half(vertexData.Normals[i].X);


### PR DESCRIPTION
- Fixed binormal handedness getting bashed in shape data, which was causing visual seaming in some cases with shape data. (Thanks Illy for help identifying this bug)

- Fixed an odd logic error in vertex data import block, where float3s were being stored instead of half4s.
   - ... I really feel like this should've created some catastrophic errors before now, but as best my testing can show, it didn't actually change anything in end results?  Possible SE had error handling for this kind of thing, but feels real weird.