### PR TITLE
Ignore duplicate vertex color streams in blender exported dae files

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Dae.cs
+++ b/xivModdingFramework/Models/FileTypes/Dae.cs
@@ -586,7 +586,6 @@ namespace xivModdingFramework.Models.FileTypes
                                                     {
                                                         vertexIndexDict.Add("normal", inputOffset);
                                                     }
-                                                    else if (semantic.Equals("color"))
                                
                                                     else if (semantic.Equals("textangent") && (source.Contains("map0") || source.Contains("map1")))
                                                     {

--- a/xivModdingFramework/Models/FileTypes/Dae.cs
+++ b/xivModdingFramework/Models/FileTypes/Dae.cs
@@ -587,9 +587,7 @@ namespace xivModdingFramework.Models.FileTypes
                                                         vertexIndexDict.Add("normal", inputOffset);
                                                     }
                                                     else if (semantic.Equals("color"))
-                                                    {
-                                                        vertexIndexDict.Add("vertexColor", inputOffset);
-                                                    }
+                               
                                                     else if (semantic.Equals("textangent") && (source.Contains("map0") || source.Contains("map1")))
                                                     {
                                                         vertexIndexDict.Add("tangent", inputOffset);
@@ -614,6 +612,10 @@ namespace xivModdingFramework.Models.FileTypes
                                                         {
                                                             vertexIndexDict.Add("vertexAlpha", inputOffset);
                                                         }
+                                                        else if (semantic.Equals("color"))
+                                                        {
+                                                            vertexIndexDict.Add("vertexColor", inputOffset);
+                                                        }
                                                     }
                                                     else if (toolType == ToolType.Blender)
 													{
@@ -629,6 +631,10 @@ namespace xivModdingFramework.Models.FileTypes
                                                         {
                                                             vertexIndexDict.Add("vertexAlpha", inputOffset);
                                                         }
+                                                        else if (semantic.Equals("color") && !vertexIndexDict.ContainsKey("vertexColor"))
+                                                        {
+                                                            vertexIndexDict.Add("vertexColor", inputOffset);
+                                                        }
                                                     }
                                                     else if (toolType == ToolType.OpenCOLLADA)
 													{
@@ -643,6 +649,10 @@ namespace xivModdingFramework.Models.FileTypes
                                                         else if (semantic.Equals("texcoord") && (source.Contains("map3") || source.Contains("uv3")))
                                                         {
                                                             vertexIndexDict.Add("vertexAlpha", inputOffset);
+                                                        }
+                                                        else if (semantic.Equals("color"))
+                                                        {
+                                                            vertexIndexDict.Add("vertexColor", inputOffset);
                                                         }
                                                     }
                                                     else


### PR DESCRIPTION
It seems that when deleting objects in blender, the color inputs can be left behind, without any geometry. This change just ignores any duplicate color inputs.

This previously resulted in "An item with the same key has already been added" exception