### PR TITLE
Safety check on tangent calculations

### DIFF
--- a/xivModdingFramework/Models/FileTypes/Mdl.cs
+++ b/xivModdingFramework/Models/FileTypes/Mdl.cs
@@ -5180,6 +5180,10 @@ namespace xivModdingFramework.Models.FileTypes
         public static Vector3Collection CalculateTangentsFromBinormals(Vector3Collection normals, Vector3Collection binormals, List<byte> handedness)
         {
             var tangents = new Vector3Collection(binormals.Count);
+            if (normals.Count != binormals.Count || normals.Count != handedness.Count)
+            {
+                return tangents;
+            }
             for(var idx = 0; idx < normals.Count; idx++)
             {
                 var tangent = Vector3.Cross(normals[idx], binormals[idx]);


### PR DESCRIPTION
Self explanatory.  Apparently some furniture items lack binormal data completely, so this fixes a viewer load failure for them.