### PR TITLE
Preset Driven Material Editor

### DIFF
--- a/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
+++ b/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
@@ -25,6 +25,7 @@ using xivModdingFramework.General.Enums;
 using xivModdingFramework.Materials.FileTypes;
 using xivModdingFramework.Textures.DataContainers;
 using xivModdingFramework.Textures.Enums;
+using xivModdingFramework.Textures.FileTypes;
 
 namespace xivModdingFramework.Materials.DataContainers
 {
@@ -432,6 +433,30 @@ namespace xivModdingFramework.Materials.DataContainers
             if (!info.HasReflection)
             {
                 SetMapInfo(XivTexType.Reflection, null);
+            }
+
+            // Clear or set the Colorset if needed.
+            if(!info.HasColorset)
+            {
+                // ColorSetCount seems to always be 1, even when the data is empty.
+                ColorSetCount = 1;
+                ColorSetData = new List<Half>();
+                ColorSetExtraData = null;
+                ColorSetDataSize = 0;
+            } else
+            {
+                if(ColorSetCount == 0 || ColorSetData == null || ColorSetData.Count != 256)
+                {
+                    // Get default Colorset Data.
+                    ColorSetData = Tex.GetColorsetDataFromDDS(Tex.GetDefaultTexturePath(XivTexType.ColorSet));
+                }
+                if(ColorSetExtraData == null || ColorSetExtraData.Length != 32)
+                {
+                    ColorSetExtraData = Tex.GetColorsetExtraDataFromDDS(Tex.GetDefaultTexturePath(XivTexType.ColorSet));
+                }
+
+                // Standard Colorset Size. -- This could really be generated automatically later.
+                ColorSetDataSize = 544;
             }
 
 

--- a/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
+++ b/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
@@ -1173,6 +1173,21 @@ namespace xivModdingFramework.Materials.DataContainers
             return "";
         }
 
+        public XivRace GetRace()
+        {
+            var races= Enum.GetValues(typeof(XivRace)).Cast<XivRace>();
+            foreach(var race in races)
+            {
+                // Test the root path for the racial identifier.
+                var match = Regex.Match(MTRLPath, "c" + race.GetRaceCode());
+                if(match.Success)
+                {
+                    return race;
+                }
+            }
+            return XivRace.All_Races;
+        }
+
 
         /// <summary>
         /// Get the root shared common texture directory for FFXIV.

--- a/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
+++ b/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
@@ -790,8 +790,8 @@ namespace xivModdingFramework.Materials.DataContainers
             }
             else if (info.Shader == MtrlShader.Standard || info.Shader == MtrlShader.Glass)
             {
-                //args.Add(MtrlShaderParameterId.Equipment1);
-                //args.Add(MtrlShaderParameterId.Reflection1);
+                args.Add(MtrlShaderParameterId.Equipment1);
+                args.Add(MtrlShaderParameterId.Reflection1);
             }
             else if (info.Shader == MtrlShader.Iris)
             {

--- a/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
+++ b/xivModdingFramework/Materials/DataContainers/XivMtrl.cs
@@ -459,7 +459,20 @@ namespace xivModdingFramework.Materials.DataContainers
                 ColorSetDataSize = 544;
             }
 
-
+            
+            // Clear out the unknown lists back to known default working values.
+            for(var idx = 0; idx < TexturePathUnknownList.Count; idx++)
+            {
+                TexturePathUnknownList[idx] = 0;
+            }
+            for (var idx = 0; idx < Unknown2.Length; idx++)
+            {
+                Unknown2[idx] = 0;
+            }
+            if (Unknown2.Length > 0)
+            {
+                Unknown2[0] = 12;
+            }
         }
 
         /// <summary>
@@ -777,8 +790,8 @@ namespace xivModdingFramework.Materials.DataContainers
             }
             else if (info.Shader == MtrlShader.Standard || info.Shader == MtrlShader.Glass)
             {
-                args.Add(MtrlShaderParameterId.Equipment1);
-                args.Add(MtrlShaderParameterId.Reflection1);
+                //args.Add(MtrlShaderParameterId.Equipment1);
+                //args.Add(MtrlShaderParameterId.Reflection1);
             }
             else if (info.Shader == MtrlShader.Iris)
             {

--- a/xivModdingFramework/Mods/FileTypes/TTMP.cs
+++ b/xivModdingFramework/Mods/FileTypes/TTMP.cs
@@ -403,6 +403,7 @@ namespace xivModdingFramework.Mods.FileTypes
             DirectoryInfo gameDirectory, DirectoryInfo modListDirectory, IProgress<(int current, int total, string message)> progress)
         {
             var dat = new Dat(gameDirectory);
+            var modding = new Modding(gameDirectory);
             var modListFullPaths = new List<string>();
             var modList = JsonConvert.DeserializeObject<ModList>(File.ReadAllText(modListDirectory.FullName));
             var modCount = 1;
@@ -466,6 +467,15 @@ namespace xivModdingFramework.Mods.FileTypes
                                                         modJson.Category.GetDisplayName(), modJson.Name,
                                                         XivDataFiles.GetXivDataFile(modJson.DatFile), _source,
                                                         GetDataType(modJson.FullPath), modJson.ModPackEntry);
+
+                                                    // Add this new entry into the mod list we're testing against
+                                                    // so we don't redundantly add files.
+                                                    var modListEntry = await modding.TryGetModEntry(modJson.FullPath);
+                                                    if(modListEntry != null)
+                                                    {
+                                                        modListFullPaths.Add(modJson.FullPath);
+                                                        modList.Mods.Add(modListEntry);
+                                                    }
                                                 }
                                             }
                                             catch (Exception ex)

--- a/xivModdingFramework/SqPack/FileTypes/Index.cs
+++ b/xivModdingFramework/SqPack/FileTypes/Index.cs
@@ -363,15 +363,23 @@ namespace xivModdingFramework.SqPack.FileTypes
             });
         }
 
+        public async Task<bool> FileExists(string fullPath)
+        {
+            var dataFile = IOUtil.GetDataFileFromPath(fullPath);
 
-        /// <summary>
-        /// Determines whether the given file path exists
-        /// </summary>
-        /// <param name="fileHash">The hashed file</param>
-        /// <param name="folderHash">The hashed folder</param>
-        /// <param name="dataFile">The data file</param>
-        /// <returns>True if it exists, False otherwise</returns>
-        public async Task<bool> FileExists(int fileHash, int folderHash, XivDataFile dataFile)
+            var pathHash = HashGenerator.GetHash(fullPath.Substring(0, fullPath.LastIndexOf("/", StringComparison.Ordinal)));
+            var fileHash = HashGenerator.GetHash(Path.GetFileName(fullPath));
+            return await FileExists(fileHash, pathHash, dataFile);
+        }
+
+            /// <summary>
+            /// Determines whether the given file path exists
+            /// </summary>
+            /// <param name="fileHash">The hashed file</param>
+            /// <param name="folderHash">The hashed folder</param>
+            /// <param name="dataFile">The data file</param>
+            /// <returns>True if it exists, False otherwise</returns>
+            public async Task<bool> FileExists(int fileHash, int folderHash, XivDataFile dataFile)
         {
             var indexPath = Path.Combine(_gameDirectory.FullName, $"{dataFile.GetDataFileName()}{IndexExtension}");
 

--- a/xivModdingFramework/Textures/FileTypes/Tex.cs
+++ b/xivModdingFramework/Textures/FileTypes/Tex.cs
@@ -1014,7 +1014,7 @@ namespace xivModdingFramework.Textures.FileTypes
         /// </summary>
         /// <param name="ddsFileDirectory"></param>
         /// <returns></returns>
-        public List<Half> GetColorsetDataFromDDS(DirectoryInfo ddsFileDirectory)
+        public static List<Half> GetColorsetDataFromDDS(DirectoryInfo ddsFileDirectory)
         {
             using (var br = new BinaryReader(File.OpenRead(ddsFileDirectory.FullName)))
             {
@@ -1059,7 +1059,7 @@ namespace xivModdingFramework.Textures.FileTypes
         /// </summary>
         /// <param name="file"></param>
         /// <returns></returns>
-        public byte[] GetColorsetExtraDataFromDDS(DirectoryInfo file)
+        public static byte[] GetColorsetExtraDataFromDDS(DirectoryInfo file)
         {
             var flagsPath = Path.Combine(Path.GetDirectoryName(file.FullName), (Path.GetFileNameWithoutExtension(file.FullName) + ".dat"));
 
@@ -1195,7 +1195,7 @@ namespace xivModdingFramework.Textures.FileTypes
         /// <summary>
         /// A dictionary containing the int represntations of known file types for DDS
         /// </summary>
-        private readonly Dictionary<int, XivTexFormat> DDSType = new Dictionary<int, XivTexFormat>
+        private static readonly Dictionary<int, XivTexFormat> DDSType = new Dictionary<int, XivTexFormat>
         {
             //DXT1
             {827611204, XivTexFormat.DXT1 },


### PR DESCRIPTION
- Significant Changes to the Material Editor interface to make it easier to use.
  - Now Preset driven.
  - Now displays status during long operations (save/etc.)
  - Can now copy/paste entire materials via the Editor.
  - Can now edit all Variant materials at the same time.
  - Can now disable/delete material edits directly from the Material Editor
  - Material Editor now re-selects the material you were just editing/just created after saving.
  - Skin, Hair, and Iris Shaders now work appropriately on all gear, with presets.
  - Glass and Standard Shader have had presets updated to help avoid ending up in broken states.

- Other
  - Fixed a crash bug when switching between items too fast in the main menu.
  - Fixed an issue with modpacks with the same file in them redundantly creating redundant mod list entries on import.