### PR TITLE
IMC Fixes

### DIFF
--- a/xivModdingFramework/Variants/DataContainers/XivImc.cs
+++ b/xivModdingFramework/Variants/DataContainers/XivImc.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using xivModdingFramework.Helpers;
+using xivModdingFramework.Variants.FileTypes;
 
 namespace xivModdingFramework.Variants.DataContainers
 {
@@ -54,12 +55,22 @@ namespace xivModdingFramework.Variants.DataContainers
         /// Returns the raw bytes that make up this IMC entry.
         /// </summary>
         /// <returns></returns>
-        public byte[] GetBytes()
+        public byte[] GetBytes(ImcType type)
         {
             var bytes = new List<byte>();
             bytes.AddRange(BitConverter.GetBytes(Variant));
             bytes.AddRange(BitConverter.GetBytes(Mask));
-            bytes.AddRange(BitConverter.GetBytes(Vfx));
+            if (type == ImcType.NonSet)
+            {
+                // Always 0 for non-set entries, their VFX number is the
+                // same as their Material Variant #.
+                bytes.AddRange(BitConverter.GetBytes(((ushort)0)));
+            }
+            else
+            {
+                // Actual VFX number.
+                bytes.AddRange(BitConverter.GetBytes(Vfx));
+            }
             return bytes.ToArray();
         }
 

--- a/xivModdingFramework/Variants/DataContainers/XivImc.cs
+++ b/xivModdingFramework/Variants/DataContainers/XivImc.cs
@@ -31,7 +31,12 @@ namespace xivModdingFramework.Variants.DataContainers
         /// <summary>
         /// The Material Set / Variant #
         /// </summary>
-        public ushort Variant { get; set; }
+        public byte Variant { get; set; }
+
+        /// <summary>
+        /// Unknown byte next to the Variant
+        /// </summary>
+        public byte Unknown { get; set; }
 
         /// <summary>
         /// The IMC mask data

--- a/xivModdingFramework/Variants/FileTypes/Imc.cs
+++ b/xivModdingFramework/Variants/FileTypes/Imc.cs
@@ -127,28 +127,32 @@ namespace xivModdingFramework.Variants.FileTypes
                     if (imcData.TypeIdentifier == ImcType.NonSet)
                     {
                         // This type uses the first short for both Variant and VFX.
-                        var variantAndVfx = br.ReadUInt16();
-                        var mask = br.ReadUInt16();
-                        var alwaysZero = br.ReadUInt16();
+                        byte variant = br.ReadByte();
+                        byte unknown = br.ReadByte();
+                        ushort mask = br.ReadUInt16();
+                        ushort alwaysZero = br.ReadUInt16();
 
                         imcData.DefaultSubset.Add(new XivImc
                         {
-                            Variant = variantAndVfx,
+                            Variant = variant,
+                            Unknown = unknown,
                             Mask = mask,
-                            Vfx = variantAndVfx
+                            Vfx = variant
                         });
 
                         for (var i = 0; i < subsetCount; i++)
                         {
-                            variantAndVfx = br.ReadUInt16();
+                            variant = br.ReadByte();
+                            unknown = br.ReadByte();
                             mask = br.ReadUInt16();
                             alwaysZero = br.ReadUInt16();
 
                             var newEntry = new XivImc
                             {
-                                Variant = variantAndVfx,
+                                Variant = variant,
+                                Unknown = unknown,
                                 Mask = mask,
-                                Vfx = variantAndVfx
+                                Vfx = variant
                             };
                             var subset = new List<XivImc>() { newEntry };
                         }
@@ -159,15 +163,15 @@ namespace xivModdingFramework.Variants.FileTypes
                         imcData.DefaultSubset = new List<XivImc>()
                         {
                             new XivImc
-                                {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                             new XivImc
-                                {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                             new XivImc
-                                {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                             new XivImc
-                                {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                             new XivImc
-                                {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                         };
 
                         for (var i = 0; i < subsetCount; i++)
@@ -176,17 +180,16 @@ namespace xivModdingFramework.Variants.FileTypes
                             var imcGear = new List<XivImc>()
                             {
                                 new XivImc
-                                    {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                    {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                                 new XivImc
-                                    {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                    {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                                 new XivImc
-                                    {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                    {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                                 new XivImc
-                                    {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                    {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                                 new XivImc
-                                    {Variant = br.ReadUInt16(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
+                                    {Variant = br.ReadByte(), Unknown = br.ReadByte(), Mask = br.ReadUInt16(), Vfx = br.ReadUInt16()},
                             };
-
                             imcData.SubsetList.Add(imcGear);
                         }
                     } else


### PR DESCRIPTION
- Fixed Material Variant being a Short instead of Byte
- Fixed Weapon IMC entries pulling VFX information from the wrong field.